### PR TITLE
Remove get coordinates auth limit

### DIFF
--- a/GroupDriveServer/resources/trips.py
+++ b/GroupDriveServer/resources/trips.py
@@ -90,10 +90,6 @@ class GetCoordinatesAPI(Resource):
         except DoesNotExist:
             raise TripNotExistsError
 
-        # Checking permissions - user must be creator
-        if trip.creator != user:
-            raise UnauthorizedError
-
         coordinates = trip.getParticipantsCoordinates()
         return Response(coordinates, status=200)
 


### PR DESCRIPTION
Removed the auth limit, so every use can
get the gps coordinates of the trip﻿
