### PR TITLE
Add delete trip call

### DIFF
--- a/GroupDriveServer/resources/trips.py
+++ b/GroupDriveServer/resources/trips.py
@@ -42,6 +42,11 @@ class TripApi(Resource):
 
         except DoesNotExist:
             raise TripNotExistsError
+
+        user = request.headers.get("username")
+        if (user != trip.creator):
+            return UnauthorizedError
+
         # Deleting all existing coordinates for this trip from the database.
         try:
             coordinates = UserLiveGPSCoordinates.objects().filter(tripID=tripId)


### PR DESCRIPTION
Delete trip call makes sure that the user
that called the api is the one that created the trip.