### PR TITLE
Add trips date filter

### DIFF
--- a/GroupDriveServer/resources/trips.py
+++ b/GroupDriveServer/resources/trips.py
@@ -61,7 +61,7 @@ class TripApi(Resource):
 
 class TripsApi(Resource):
     def get(self):
-        trips = Trip.objects().order_by('date')
+        trips = Trip.objects(date__gte=dt.today).order_by('date')
         tripsList = []
         creator_filter = request.headers.get("creator")
             


### PR DESCRIPTION
Filter the dates by returning only those who have dates that are
greater than or equal to today - i.e. hide from the user old trips.