### PR TITLE
Delete coordinates of user leaving a trip

### DIFF
--- a/GroupDriveServer/database/models.py
+++ b/GroupDriveServer/database/models.py
@@ -47,6 +47,9 @@ class Trip(Document):
             self.save()
         else: 
             self.participants.remove(str(username))
+            coors = UserLiveGPSCoordinates.objects(tripID = self._id, user = str(username))
+            if coors:
+                coors.delete()
             self.save()
 
     def get_participants_coordinates(self):


### PR DESCRIPTION
When a user leaves the trip - the server deletes his coordinates
from the database